### PR TITLE
Allow date to be undefined.

### DIFF
--- a/src/single.tsx
+++ b/src/single.tsx
@@ -18,7 +18,7 @@ import {
 } from './utils/commonTypes';
 
 export interface SingleDatepickerProps extends DatepickerProps {
-  date: Date;
+  date?: Date;
   configs?: DatepickerConfigs;
   disabled?: boolean;
   onDateChange: (date: Date) => void;
@@ -83,7 +83,7 @@ export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
           ref={initialFocusRef}
           onClick={() => setPopoverOpen(!popoverOpen)}
           name={name}
-          value={format(date, configs.dateFormat)}
+          value={date ? format(date, configs.dateFormat) : ''}
           onChange={(e) => e.target.value}
           {...propsConfigs?.inputProps}
         />

--- a/test/single.test.tsx
+++ b/test/single.test.tsx
@@ -11,4 +11,13 @@ describe('it', () => {
     );
     ReactDOM.unmountComponentAtNode(div);
   });
+
+  it('renders without crashing with undefined date', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(
+      <SingleDatepicker date={undefined} onDateChange={() => {}} />,
+      div
+    );
+    ReactDOM.unmountComponentAtNode(div);
+  });
 });


### PR DESCRIPTION
This fix allows undefined dates to be used without causing an error. For my use case I don't want to initialize the date to today's date. I want the user to select the date and the field should be initially blank. This fixes #2.  

The changes are pretty straightforward. It doesn't require you to encapsulate the date state or make any other changes. It should work for your use case as well as mine.