### PR TITLE
add Portal option to popover

### DIFF
--- a/src/range.tsx
+++ b/src/range.tsx
@@ -10,6 +10,7 @@ import {
   PopoverContent,
   PopoverTrigger,
   useOutsideClick,
+  Portal,
 } from '@chakra-ui/react';
 import { CalendarPanel } from './components/calendarPanel';
 import {
@@ -122,6 +123,7 @@ export interface RangeDatepickerProps extends DatepickerProps {
   onDateChange: (date: Date[]) => void;
   id?: string;
   name?: string;
+  usePortal?: boolean;
 }
 
 const DefaultConfigs = {
@@ -136,6 +138,7 @@ export const RangeDatepicker: React.FC<RangeDatepickerProps> = ({
   initDate = new Date(),
   id,
   name,
+  usePortal,
   ...props
 }) => {
   const { selectedDates, minDate, maxDate, onDateChange, disabled } = props;
@@ -192,6 +195,8 @@ export const RangeDatepicker: React.FC<RangeDatepickerProps> = ({
     ? ` - ${format(selectedDates[1], configs.dateFormat)}`
     : '';
 
+  const PopoverContentWrapper = usePortal ? Portal : React.Fragment;
+
   return (
     <Popover
       placement="bottom-start"
@@ -214,16 +219,18 @@ export const RangeDatepicker: React.FC<RangeDatepickerProps> = ({
           {...propsConfigs.inputProps}
         />
       </PopoverTrigger>
-      <PopoverContent ref={ref} width="100%">
-        <PopoverBody>
-          <RangeCalendarPanel
-            renderProps={dayzedData}
-            configs={configs}
-            propsConfigs={propsConfigs}
-            selected={selectedDates}
-          />
-        </PopoverBody>
-      </PopoverContent>
+      <PopoverContentWrapper>
+        <PopoverContent ref={ref} width="100%">
+          <PopoverBody>
+            <RangeCalendarPanel
+              renderProps={dayzedData}
+              configs={configs}
+              propsConfigs={propsConfigs}
+              selected={selectedDates}
+            />
+          </PopoverBody>
+        </PopoverContent>
+      </PopoverContentWrapper>
     </Popover>
   );
 };

--- a/src/single.tsx
+++ b/src/single.tsx
@@ -6,6 +6,7 @@ import {
   PopoverContent,
   PopoverTrigger,
   useOutsideClick,
+  Portal,
 } from '@chakra-ui/react';
 import { useDayzed } from 'dayzed';
 import { format } from 'date-fns';
@@ -24,6 +25,7 @@ export interface SingleDatepickerProps extends DatepickerProps {
   onDateChange: (date: Date) => void;
   id?: string;
   name?: string;
+  usePortal?: boolean;
 }
 
 const DefaultConfigs = {
@@ -35,6 +37,7 @@ const DefaultConfigs = {
 export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
   configs = DefaultConfigs,
   propsConfigs,
+  usePortal,
   ...props
 }) => {
   const { date, name, disabled, onDateChange, id } = props;
@@ -66,6 +69,8 @@ export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
     selected: date,
   });
 
+  const PopoverContentWrapper = usePortal ? Portal : React.Fragment;
+
   return (
     <Popover
       placement="bottom-start"
@@ -88,15 +93,17 @@ export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
           {...propsConfigs?.inputProps}
         />
       </PopoverTrigger>
-      <PopoverContent ref={ref} width="100%">
-        <PopoverBody>
-          <CalendarPanel
-            renderProps={dayzedData}
-            configs={configs}
-            propsConfigs={propsConfigs}
-          />
-        </PopoverBody>
-      </PopoverContent>
+      <PopoverContentWrapper>
+        <PopoverContent ref={ref} width="100%">
+          <PopoverBody>
+            <CalendarPanel
+              renderProps={dayzedData}
+              configs={configs}
+              propsConfigs={propsConfigs}
+            />
+          </PopoverBody>
+        </PopoverContent>
+      </PopoverContentWrapper>
     </Popover>
   );
 };


### PR DESCRIPTION
Issue: parent clipping content of popover.

Example: have a `SingleDatePicker` in a sidebar on my app.  The sidebar (parent) for the `SingleDatePicker` is clipping the content.
<img width="293" alt="image" src="https://user-images.githubusercontent.com/13009706/160208291-ee6f002f-9300-41bc-aa94-f712bd4fd41b.png">

Fix addressed in this PR: make use of Chakra UI's `Portal`
A `Portal` component will ["prevent parent styles from clipping or hiding content (for popovers...)"](https://chakra-ui.com/docs/components/other/portal).

I've added the `Portal` in an optional and conditional manner, so code is still backwards-compatible.