### PR TITLE
Enhance configs Prop in RangeDatepicker to Include monthsToDisplay

### DIFF
--- a/src/range.tsx
+++ b/src/range.tsx
@@ -97,6 +97,7 @@ const DefaultConfigs: CalendarConfigs = {
   monthNames: Month_Names_Short,
   dayNames: Weekday_Names_Short,
   firstDayOfWeek: 0,
+  monthsToDisplay: 2,
 };
 
 export const RangeDatepicker: React.FC<RangeDatepickerProps> = ({
@@ -203,7 +204,7 @@ export const RangeDatepicker: React.FC<RangeDatepickerProps> = ({
                 dayzedHookProps={{
                   onDateSelected: handleOnDateSelected,
                   selected: selectedDates,
-                  monthsToDisplay: 2,
+                  monthsToDisplay: calendarConfigs.monthsToDisplay,
                   date: dateInView,
                   minDate: minDate,
                   maxDate: maxDate,

--- a/src/range.tsx
+++ b/src/range.tsx
@@ -92,7 +92,7 @@ export interface RangeDatepickerProps extends DatepickerProps {
   usePortal?: boolean;
 }
 
-const DefaultConfigs: CalendarConfigs = {
+const DefaultConfigs: Required<DatepickerConfigs> = {
   dateFormat: 'MM/dd/yyyy',
   monthNames: Month_Names_Short,
   dayNames: Weekday_Names_Short,
@@ -117,7 +117,7 @@ export const RangeDatepicker: React.FC<RangeDatepickerProps> = ({
   const [offset, setOffset] = useState(0);
   const { onOpen, onClose, isOpen } = useDisclosure({ defaultIsOpen });
 
-  const calendarConfigs: CalendarConfigs = {
+  const datepickerConfigs = {
     ...DefaultConfigs,
     ...configs,
   };
@@ -159,10 +159,10 @@ export const RangeDatepicker: React.FC<RangeDatepickerProps> = ({
 
   // eventually we want to allow user to freely type their own input and parse the input
   let intVal = selectedDates[0]
-    ? `${format(selectedDates[0], calendarConfigs.dateFormat)}`
+    ? `${format(selectedDates[0], datepickerConfigs.dateFormat)}`
     : '';
   intVal += selectedDates[1]
-    ? ` - ${format(selectedDates[1], calendarConfigs.dateFormat)}`
+    ? ` - ${format(selectedDates[1], datepickerConfigs.dateFormat)}`
     : '';
 
   const PopoverContentWrapper = usePortal ? Portal : React.Fragment;
@@ -204,15 +204,15 @@ export const RangeDatepicker: React.FC<RangeDatepickerProps> = ({
                 dayzedHookProps={{
                   onDateSelected: handleOnDateSelected,
                   selected: selectedDates,
-                  monthsToDisplay: calendarConfigs.monthsToDisplay,
+                  monthsToDisplay: datepickerConfigs.monthsToDisplay,
                   date: dateInView,
                   minDate: minDate,
                   maxDate: maxDate,
                   offset: offset,
                   onOffsetChanged: setOffset,
-                  firstDayOfWeek: calendarConfigs.firstDayOfWeek,
+                  firstDayOfWeek: datepickerConfigs.firstDayOfWeek,
                 }}
-                configs={calendarConfigs}
+                configs={datepickerConfigs}
                 propsConfigs={propsConfigs}
                 selected={selectedDates}
               />

--- a/src/single.tsx
+++ b/src/single.tsx
@@ -13,7 +13,6 @@ import FocusLock from 'react-focus-lock';
 import { Month_Names_Short, Weekday_Names_Short } from './utils/calanderUtils';
 import { CalendarPanel } from './components/calendarPanel';
 import {
-  CalendarConfigs,
   DatepickerConfigs,
   DatepickerProps,
   OnDateSelected,

--- a/src/single.tsx
+++ b/src/single.tsx
@@ -35,7 +35,7 @@ export interface SingleDatepickerProps extends DatepickerProps {
   usePortal?: boolean;
 }
 
-const DefaultConfigs: CalendarConfigs = {
+const DefaultConfigs: Required<DatepickerConfigs> = {
   dateFormat: 'yyyy-MM-dd',
   monthNames: Month_Names_Short,
   dayNames: Weekday_Names_Short,
@@ -67,7 +67,7 @@ export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
 
   const { onOpen, onClose, isOpen } = useDisclosure({ defaultIsOpen });
 
-  const calendarConfigs: CalendarConfigs = {
+  const datepickerConfigs = {
     ...DefaultConfigs,
     ...configs,
   };
@@ -112,7 +112,9 @@ export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
           isDisabled={disabled}
           name={name}
           value={
-            selectedDate ? format(selectedDate, calendarConfigs.dateFormat) : ''
+            selectedDate
+              ? format(selectedDate, datepickerConfigs.dateFormat)
+              : ''
           }
           onChange={(e) => e.target.value}
           {...propsConfigs?.inputProps}
@@ -128,7 +130,7 @@ export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
               <CalendarPanel
                 dayzedHookProps={{
                   showOutsideDays: true,
-                  monthsToDisplay: calendarConfigs.monthsToDisplay,
+                  monthsToDisplay: datepickerConfigs.monthsToDisplay,
                   onDateSelected: handleOnDateSelected,
                   selected: selectedDate,
                   date: dateInView,
@@ -136,9 +138,9 @@ export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
                   maxDate: maxDate,
                   offset: offset,
                   onOffsetChanged: setOffset,
-                  firstDayOfWeek: calendarConfigs.firstDayOfWeek,
+                  firstDayOfWeek: datepickerConfigs.firstDayOfWeek,
                 }}
-                configs={calendarConfigs}
+                configs={datepickerConfigs}
                 propsConfigs={propsConfigs}
                 disabledDates={disabledDates}
               />

--- a/src/single.tsx
+++ b/src/single.tsx
@@ -40,6 +40,7 @@ const DefaultConfigs: CalendarConfigs = {
   monthNames: Month_Names_Short,
   dayNames: Weekday_Names_Short,
   firstDayOfWeek: 0,
+  monthsToDisplay: 1,
 };
 
 export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
@@ -127,6 +128,7 @@ export const SingleDatepicker: React.FC<SingleDatepickerProps> = ({
               <CalendarPanel
                 dayzedHookProps={{
                   showOutsideDays: true,
+                  monthsToDisplay: calendarConfigs.monthsToDisplay,
                   onDateSelected: handleOnDateSelected,
                   selected: selectedDate,
                   date: dateInView,

--- a/src/utils/commonTypes.ts
+++ b/src/utils/commonTypes.ts
@@ -64,4 +64,5 @@ export interface CalendarConfigs {
   monthNames: string[];
   dayNames: string[];
   firstDayOfWeek: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  monthsToDisplay: number;
 }

--- a/src/utils/commonTypes.ts
+++ b/src/utils/commonTypes.ts
@@ -65,5 +65,4 @@ export interface CalendarConfigs {
   monthNames: string[];
   dayNames: string[];
   firstDayOfWeek: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-  monthsToDisplay: number;
 }

--- a/src/utils/commonTypes.ts
+++ b/src/utils/commonTypes.ts
@@ -57,6 +57,7 @@ export interface DatepickerConfigs {
   monthNames?: string[];
   dayNames?: string[];
   firstDayOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  monthsToDisplay?: number;
 }
 
 export interface CalendarConfigs {


### PR DESCRIPTION
This PR introduces a new enhancement to the RangeDatepicker component. With this update, users can now specify the number of months they want to display in the datepicker.

This enhancement allows for greater flexibility when integrating the datepicker into various user interfaces, especially where space or user experience considerations might dictate displaying a different number of months.

Please review and let me know if any further changes are required.