### PR TITLE
Allow selected styling while being disabled

### DIFF
--- a/src/components/dayOfMonth.tsx
+++ b/src/components/dayOfMonth.tsx
@@ -89,7 +89,7 @@ export const DayOfMonth: React.FC<DayOfMonthProps> = ({
       isDisabled={disabled}
       {...styleBtnProps.defaultBtnProps}
       {...(isInRange && !disabled && styleBtnProps.isInRangeBtnProps)}
-      {...(selected && !disabled && styleBtnProps.selectedBtnProps)}
+      {...(selected && styleBtnProps.selectedBtnProps)}
       {...(today && styleBtnProps.todayBtnProps)}
     >
       {date.getDate()}


### PR DESCRIPTION
As part of #76, this PR proposes to allow the selectedBtnProps even if a given dayOfMonth is disabled (e.g. being below minDate). The element remains disabled, both functionally and visually, yet allows the component to indicate that there is indeed a selected date (and/or likely range) that exists outside of the currently selectable/valid range.
An example of what this looks like is shown here:
![Screenshot 2024-03-22 at 4 14 38 PM](https://github.com/aboveyunhai/chakra-dayzed-datepicker/assets/6148480/1fe18858-f9a1-4717-9911-8b97c0aed50a)

I'd imagine this is closer to expected behavior, so don't _think_ it's necessarily required to add additional props to allow this behavior sometimes, but am certainly open to that if you disagree.

Thanks for considering!