### PR TITLE
Moved required dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     }
   ],
   "devDependencies": {
+    "@chakra-ui/react": "^1.7.3",
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@size-limit/preset-small-lib": "^6.0.4",
@@ -75,7 +76,6 @@
   },
   "dependencies": {
     "react-focus-lock": "^2.9.5",
-    "@chakra-ui/react": "^1.7.3",
     "date-fns": "^2.23.0",
     "dayzed": "^3.2.2"
   }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     }
   ],
   "devDependencies": {
-    "@chakra-ui/react": "^1.7.3",
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@size-limit/preset-small-lib": "^6.0.4",
@@ -65,8 +64,6 @@
     "@tsconfig/recommended": "^1.0.1",
     "@types/react": "^17.0.15",
     "@types/react-dom": "^17.0.9",
-    "date-fns": "^2.23.0",
-    "dayzed": "^3.2.2",
     "dts-cli": "^1.6.3",
     "framer-motion": "^4.1.17",
     "husky": "^7.0.4",
@@ -77,6 +74,9 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "react-focus-lock": "^2.9.5"
+    "react-focus-lock": "^2.9.5",
+    "@chakra-ui/react": "^1.7.3",
+    "date-fns": "^2.23.0",
+    "dayzed": "^3.2.2"
   }
 }


### PR DESCRIPTION
When installing `chakra-dayzed-datepicker`, `@chakra-ui/react, date-fns` and `dayzed` are required.

You could install them seperately, but thats an additonal step for the user. It also clutters the users package.json unnecessarily.

In addition, I've had issues with depcheck (https://www.npmjs.com/package/depcheck) complaining I have unused deps. (Due to `date-fns` and `dayzed` not being used outside `chakra-dayzed-datepicker` in my program)

It would be easier if these are listed as direct dependencies, and that is the purpose of this PR.